### PR TITLE
Add screen wake lock to Reader Page

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -67,7 +67,7 @@ if (!self.define) {
     });
   };
 }
-define(['./workbox-02b5fe2a'], (function (workbox) { 'use strict';
+define(['./workbox-e7681877'], (function (workbox) { 'use strict';
 
   self.skipWaiting();
   workbox.clientsClaim();
@@ -82,29 +82,13 @@ define(['./workbox-02b5fe2a'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.4ob9bv0u4g8"
+    "revision": "0.mp26ih0bm2k"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {
     allowlist: [/^\/$/],
     denylist: [/^\/api/]
   }));
-  workbox.registerRoute(/^https:\/\/fonts\.googleapis\.com\/.*/i, new workbox.StaleWhileRevalidate({
-    "cacheName": "google-fonts-stylesheets",
-    plugins: [new workbox.ExpirationPlugin({
-      maxEntries: 10,
-      maxAgeSeconds: 31536000
-    })]
-  }), 'GET');
-  workbox.registerRoute(/^https:\/\/fonts\.gstatic\.com\/.*/i, new workbox.CacheFirst({
-    "cacheName": "google-fonts-webfonts",
-    plugins: [new workbox.ExpirationPlugin({
-      maxEntries: 30,
-      maxAgeSeconds: 31536000
-    }), new workbox.CacheableResponsePlugin({
-      statuses: [0, 200]
-    })]
-  }), 'GET');
   workbox.registerRoute(/^https?:\/\/[^/]+\/?$/, new workbox.NetworkFirst({
     "cacheName": "app-shell",
     plugins: [new workbox.ExpirationPlugin({


### PR DESCRIPTION
## Summary
- Implements Wake Lock API to keep screen awake during reading sessions
- Automatically releases lock after 40 minutes of inactivity
- Handles visibility changes (releases when hidden, reacquires when visible)
- Gracefully handles browsers without wake lock support

## Test plan
- [ ] Test wake lock activation when entering Reader Page
- [ ] Verify screen stays awake during reading
- [ ] Confirm lock releases after 40 minutes of no interaction
- [ ] Test lock reacquisition when returning to page after switching tabs
- [ ] Verify functionality in browsers with and without wake lock support

🤖 Generated with [Claude Code](https://claude.com/claude-code)