### PR TITLE
Replace swipe-down with double-tap bookmark gesture

### DIFF
--- a/dev-dist/sw.js
+++ b/dev-dist/sw.js
@@ -82,7 +82,7 @@ define(['./workbox-e7681877'], (function (workbox) { 'use strict';
     "revision": "3ca0b8505b4bec776b69afdba2768812"
   }, {
     "url": "index.html",
-    "revision": "0.mp26ih0bm2k"
+    "revision": "0.j1bb66fvrhk"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("index.html"), {


### PR DESCRIPTION
## Summary
- Replace swipe-down bookmark gesture with double-tap (500ms window for easier tapping)
- Add smooth fade-in and slide-up animations to all modal dialogs (chapters, settings, bookmarks, add bookmark)
- Fix auto-advance behavior to remain paused while bookmark modal is open

## Test plan
- [ ] Test double-tap gesture to open bookmark modal
- [ ] Verify animations are smooth when opening modals
- [ ] Confirm auto-advance remains paused while bookmark modal is open
- [ ] Test that auto-advance resumes correctly after closing modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)